### PR TITLE
mat dialog config disableClose: true

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,3 +8,4 @@
 - [ ] Lint Fix
 - [ ] Unit Tests
 - [ ] WCAG Compliant
+- [ ] Bump Version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wigedev-fitness-log",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --port 5000",

--- a/src/app/common/services/ui/ui.service.ts
+++ b/src/app/common/services/ui/ui.service.ts
@@ -1,6 +1,7 @@
+import { MatDialog, MatDialogRef } from '@angular/material/dialog'
+
 import { ComponentType } from '@angular/cdk/portal'
 import { Injectable } from '@angular/core'
-import { MatDialog, MatDialogRef } from '@angular/material/dialog'
 import { MatSnackBar } from '@angular/material/snack-bar'
 
 @Injectable({
@@ -20,7 +21,7 @@ export class UiService {
   }
 
   showDialog(component: ComponentType<unknown>, data: any = null, isSubDialog: boolean = false): MatDialogRef<unknown> {
-    return this.dialog.open(component, { width: isSubDialog ? '380px' : '420px', data: data })
+    return this.dialog.open(component, { width: isSubDialog ? '380px' : '420px', data: data, disableClose: true })
   }
 
   closeAllDialogs() {


### PR DESCRIPTION
# Description

dialogs will no longer close after clicking outside of the dialog

# Developer Checklist

- [x] NPM Audit
- [x] Update README
- [x] Style Fix
- [x] Lint Fix
- [x] Unit Tests
- [x] WCAG Compliant
